### PR TITLE
Fix flaky tests in guava.

### DIFF
--- a/guava/src/test/java/com/fasterxml/jackson/datatype/guava/FluentIterableTest.java
+++ b/guava/src/test/java/com/fasterxml/jackson/datatype/guava/FluentIterableTest.java
@@ -4,6 +4,8 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Sets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * Unit tests to verify serialization of {@link FluentIterable}s.
@@ -25,6 +27,13 @@ public class FluentIterableTest extends ModuleTestBase
      * or Guava's implementation of FluentIterable changes.
      * @throws Exception
      */
+    private void assertJsonEqualsNonStrict(String json0, String json1) {
+        try {
+            JSONAssert.assertEquals(json0, json1, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
     public void testSerializationWithoutModule() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         FluentHolder holder = new FluentHolder();
@@ -34,13 +43,13 @@ public class FluentIterableTest extends ModuleTestBase
 
     public void testSerialization() throws Exception {
         String json = MAPPER.writeValueAsString(createFluentIterable());
-        assertEquals("[1,2,3]", json);
+        assertJsonEqualsNonStrict("[1,2,3]", json);
     }
 
     public void testWrappedSerialization() throws Exception {
         FluentHolder holder = new FluentHolder();
         String json = MAPPER.writeValueAsString(holder);
-        assertEquals("{\"value\":[1,2,3]}", json);
+        assertJsonEqualsNonStrict("{\"value\":[1,2,3]}", json);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>


### PR DESCRIPTION
1. Test failures:
- Run:
 `mvn -pl guava edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.fasterxml.jackson.datatype.guava.FluentIterableTest`, 
  *Here are the details of [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- Two tests fail:
 `com.fasterxml.jackson.datatype.guava.FluentIterableTest.testSerialization`
 `com.fasterxml.jackson.datatype.guava.FluentIterableTest.testWrappedSerialization`

- The failures:
```
at com.fasterxml.jackson.datatype.guava.FluentIterableTest.testSerialization(FluentIterableTest.java:37)
[ERROR] Failures:
[ERROR]   FluentIterableTest.testSerialization:37 expected:<[[1,2,3]]> but was:<[[3,1,2]]>
```
```
at com.fasterxml.jackson.datatype.guava.FluentIterableTest.testWrappedSerialization(FluentIterableTest.java:43)
[ERROR] Failures:
[ERROR]   FluentIterableTest.testWrappedSerialization:43 expected:<{"value":[[1,2,3]]}> but was:<{"value":[[3,1,2]]}>
```
2. Why they fail:
- The 2 tests fail for the same reason, `MAPPER.writeValueAsString()` serializes Java objects as JSON output, but the order of objects being mapped into a string by ObjectMapper changes, resulting in a different serialized JSON string.
3. Fix them:
- Check JSON results by JSONAssert and test assertions changes, also need to add the dependency for `org.skyscreamer.jsonassert`.


